### PR TITLE
fix left_eye_id error

### DIFF
--- a/LanceScript.lua
+++ b/LanceScript.lua
@@ -5467,7 +5467,7 @@ local function set_up_player_actions(pid)
                 case 14: 
                     send_attacker("CLONE", pid, false, num_attackers)
                     break
-                pluto_default:
+                default:
                     send_attacker(attacker_hashes[index], pid, false, num_attackers, atkgun)
             end
     end)

--- a/LanceScript.lua
+++ b/LanceScript.lua
@@ -1276,7 +1276,7 @@ self_root:toggle_loop(translations.laser_eyes, {"lasereyes"}, translations.laser
             -- michael / story mode character
             case 225514697:
             -- imply they're using a story mode ped i guess. i dont know what else to do unless i have data on every single ped
-            pluto_default:
+            default:
                 left_eye_id = 5956
                 right_eye_id = 6468
         end


### PR DESCRIPTION
Looks like `pluto_default` has been removed and just `default` works now